### PR TITLE
fix: make HttpException handle response with no body properly

### DIFF
--- a/mantelo/exceptions.py
+++ b/mantelo/exceptions.py
@@ -25,7 +25,7 @@ class HttpException(Exception):
 
     status_code: int
     """The HTTP status code."""
-    json: str
+    json: dict
     """The JSON response from the server."""
     url: str
     """The URL that was requested."""
@@ -38,6 +38,6 @@ class HttpException(Exception):
         return cls(
             url=ex.response.request.url,
             status_code=ex.response.status_code,
-            json=ex.response.json(),
+            json=ex.response.json() if ex.response.content else {},
             response=ex.response,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -116,6 +116,7 @@ def test_switch_realm(openid_connection_admin):
         (403, lambda c: c.clients.get()),
         (400, lambda c: c.users.post({"foo": "bar"})),
         (400, lambda c: c.users.post({})),
+        (405, lambda c: c.groups.head()),
         (405, lambda c: c.users.put({})),
         (404, lambda c: c.users("not-exist").get()),
         (
@@ -140,7 +141,7 @@ def test_exceptions(openid_connection_password, status, op):
     ex = excinfo.value
     assert ex.status_code == status
     assert ex.url.startswith(constants.TEST_SERVER_URL)
-    assert ex.json and isinstance(ex.json, dict)
+    assert isinstance(ex.json, dict)
     assert isinstance(ex.response, requests.Response)
 
 


### PR DESCRIPTION
A call to HEAD returns an empty body, which makes the `.json()` throw a decode exception.

This commit fixes it by always returning a dict in the exceptions's `json` and guarding against None body.