### PR TITLE
feat!: remove dependency on Slumber and integrate its functionality i…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           release-type: simple
           changelog-types: '[{"type":"feat","section":"🚀 Features","hidden":false},{"type":"fix","section":"🐛 Bug Fixes","hidden":false},{"type":"docs","section":"💬 Documentation","hidden":false},{"type":"ci","section":"🦀 Build and CI","hidden":false}, {"type":"style","section":"🌈 Styling","hidden":false}]'
-          extra-files: build.gradle.kts
 
   publish:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ test: ## Run tests with tox (inside docker).
 mypy: ## Run mypy locally to check types.
 	mypy mantelo
 
+mypy-strict: ## Run mypy locally and print all missing annotations.
+	mypy --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs mantelo
+
 export-realms: ## Export test realms after changes in Keycloak Test Server.
 	docker compose exec keycloak /opt/keycloak/bin/kc.sh export --dir /tmp/export --users realm_file; \
     for realm in master orwell; do \

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ HttpException: (403, {'error': 'unknown_error', 'error_description': 'For more o
 
 If the server returns a 401 Unauthorized during the _authentication_ process, mantelo will raise an
 `AuthenticationException` with the `error` and `errorDescription` from Keycloak. All other HTTP
-exceptions are instances of `HttpException`.
+exceptions are instances of `HttpException`, with some subclasses (`HttpNotFound`, `HttpClientError`, `HttpServerError`).
 
 Here are some examples:
 

--- a/docs/01-authentication.rst
+++ b/docs/01-authentication.rst
@@ -9,15 +9,14 @@
 ==============================
 
 To authenticate to Keycloak, you can either use a username+password, or client credentials (client
-ID+client secret, also known as service account).
+ID+client secret, also known as *service account*).
 
 The library takes care of fetching a token the first time you need it and keeping it fresh. By
 default, it tries to use the refresh token (if available) and always guarantees the token is valid
-for the next 30s.
+for the next 30 seconds.
 
-The authentication calls and the calls to the REST API are using the same
-:py:class:`requests.Session`, that can be passed at creation in case you need to add custom headers,
-proxies, etc.
+The authentication calls and the calls to the REST API use the same :py:class:`requests.Session`,
+which can be passed at creation in case you need to add custom headers, proxies, etc.
 
 .. important::
 
@@ -37,7 +36,7 @@ testing, you can either use the admin user (not recommended) or create a user an
 
 .. hint::
 
-    Clients need to enable the "*Direct access grants*" authorization flow.
+    Clients must enable the "*Direct access grants*" authorization flow.
     The client ``admin-cli``, which exists by default on all realms, is often used.
 
 Here is how to use :py:meth:`~.KeycloakAdmin.from_username_password` connect to the default realm

--- a/docs/02-making-calls.rst
+++ b/docs/02-making-calls.rst
@@ -18,8 +18,9 @@ depending on how you call the client.
 The return value is the HTTP response content as a :python:`dict` (parsed from the JSON response). In
 case of error, an :py:class:`~.HttpException` with access to the raw response is available.
 
-All the calls in the chain are used to generate the URL, except for the last call which determines the HTTP method to use.
-Supported HTTP methods are:
+All the calls in the chain are used to generate the URL, except for the last call which determines
+the HTTP method to use. Supported HTTP methods are (see :py:class:`~.Resource` for more
+information):
 
 * :python:`.get(**kwargs)`
 * :python:`.options(**kwargs)`
@@ -29,8 +30,8 @@ Supported HTTP methods are:
 * :python:`.put(data=None, files=None, **kwargs)`
 * :python:`.delete(**kwargs)`
 
-The ``kwargs`` are used to add query parameters to the URL. The ``data`` and ``files`` parameters
-are used to add a payload to the request. See :py:meth:`requests.Session.request` for more
+The ``kwargs`` can be used to add query parameters to the URL. The ``data`` and ``files`` parameters
+can be used to add a payload to the request. See :py:meth:`requests.Session.request` for more
 information on the allowed values for these parameters.
 
 .. note::
@@ -115,6 +116,27 @@ You can use:
 
 Note that you could also use ``c("client-scopes").get()``, but let's admit it, it is ugly (so
 don't).
+
+About the return type of HTTP calls
+-----------------------------------
+
+HTTP calls return the JSON response as a Python dictionary, with the following exceptions:
+
+1. When the HTTP method is ``DELETE``, the return value is a boolean indicating success (2xx status
+   code) or failure (other status codes).
+2. When the response is empty, the return value is an empty string, to match :py:mod:`requests` behavior.
+3. When the content-type of the response doesn't match a JSON content-type, mantelo returns the
+   response text as a string, or the raw bytes if the body can not be decoded. It does not
+   attempt any parsing.
+
+In case of error, an :py:class:`~.HttpException` is raised, with the raw response available in the 
+:py:attr:`~HttpException.response` attribute.
+
+Finally, there may be times when you need to access the raw response object. For this, use the
+:py:meth:`~.Resource.as_raw` method anywhere in the chain. This will make mantelo return a tuple
+instead, with the raw :py:class:`requests.Response` as the first element. The second element is
+the decoded content, and follow the same rules as laid above.
+
 
 Special case: working with realms
 ---------------------------------

--- a/docs/03-examples.rst
+++ b/docs/03-examples.rst
@@ -9,8 +9,10 @@
 📓 Examples
 ===========
 
-Assuming you created a client (see :ref:`authentication`), here are some examples of how to interact with the Keycloak Admin API using Mantelo.
-Don't hesitate to create an `issue <https://github.com/derlin/mantelo/issues/new/choose>`_ if you want to see more examples or if you have any questions.
+Assuming you created a client (see :ref:`authentication`), here are some examples of how to interact
+with the Keycloak Admin API using Mantelo. Don't hesitate to create an
+`issue <https://github.com/derlin/mantelo/issues/new/choose>`_ if you want to see more examples or
+if you have any questions.
 
 Create, update, and delete a user
 ---------------------------------
@@ -39,7 +41,7 @@ Create, update, and delete a user
     ...    "enabled": True,
     ...    "emailVerified": True,
     ... })
-    b''
+    ''
 
     # Get the ID of the newly created user
     >>> user_id = client.users.get(username="test_user")[0]["id"]
@@ -49,6 +51,7 @@ Create, update, and delete a user
 
     # Add some password credentials
     >>> client.users(user_id).put({"credentials": [{"type": "password", "value": "CHANGE_ME"}]})
+    ''
 
     >>> client.users(user_id).credentials.get()
     [{'id': ..., 'type': 'password', 'createdDate': ..., 'credentialData': ...}]
@@ -91,7 +94,8 @@ List and count resources
 Interact with realms directly
 -----------------------------
 
-If you need to view or edit properties of the current realm (``/admin/realm/{realm}`` endpoint), you can use the client directly:
+If you need to view or edit properties of the current realm (``/admin/realm/{realm}`` endpoint), you
+can use the client directly:
 
 .. doctest::
 
@@ -101,10 +105,11 @@ If you need to view or edit properties of the current realm (``/admin/realm/{rea
 
         # Update the realm
         >>> client.put({"displayName": "MASTER!"})
+        ''
 
 You can at any point change the realm of the client by setting the
 :py:attr:`~.KeycloakAdmin.realm_name`. This won't impact the connection, which will still use the
-same token. This is useful when you want to definitely switch to another realm. If you only need to
+same token. This is useful when you want to switch to another realm definitely. If you only need to
 do a few operations in another realm, consider using the :py:attr:`~.KeycloakAdmin.realms` instead
 (keep reading).
 
@@ -134,7 +139,7 @@ or simply to quickly query another realm's information, use the special `~.Keycl
 
     # Create a new realm
     >>> client.realms.post({"realm": "new_realm", "enabled": True, "displayName": "New Realm"})
-    b''
+    ''
 
     # Get the new realm
     >>> client.realms("new_realm").get()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,12 +10,11 @@ Mantelo: A Keycloak Admin REST Api Client for Python
 
    Mantelo [manˈtelo], from German "*Mantel*", from Late Latin "*mantum*" means "*cloak*" in Esperanto.
 
-It stays always **fresh** and **complete** because it does not implement or wrap any endpoint.
-Instead, it offers an object-oriented interface to the Keycloak ReSTful API. Acting as a wrapper
-around the well-known `requests <https://requests.readthedocs.io/en/latest/>`_ library, it abstracts
-all the boring stuff such as authentication (tokens and refresh tokens), URL handling,
-serialization, and the processing of requests. This magic is made possible by the excellent
-`slumber <https://slumber.readthedocs.io/>`_ library.
+It always stays **fresh** and **complete** because it does not hard-code or wrap any endpoint.
+Instead, Instead, it offers a clean, object-oriented interface to the Keycloak RESTful API. Acting
+as a lightweight wrapper around the popular `requests <https://requests.readthedocs.io/en/latest/>`_
+library, mantelo takes care of all the boring details for you - like authentication (tokens and
+refresh tokens), URL management, serialization, and request processing [#mention]_.
 
 ⮕ Any endpoint your Keycloak supports, mantelo supports!
 
@@ -40,3 +39,7 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+-------------------
+
+.. [#mention] A big thanks to the excellent `slumber <https://slumber.readthedocs.io/>`_ library, which inspired this project.

--- a/mantelo/exceptions.py
+++ b/mantelo/exceptions.py
@@ -1,10 +1,16 @@
 import requests
 from attrs import field, frozen
-from slumber.exceptions import SlumberHttpBaseException
 
 
 @frozen
-class AuthenticationException(Exception):
+class ManteloException(Exception):
+    """
+    Base exception for all exceptions raised by the Mantelo library.
+    """
+
+
+@frozen
+class AuthenticationException(ManteloException):
     """
     Exception raised when the authentication request fails with a `401 Unauthorized` status code.
     """
@@ -18,7 +24,7 @@ class AuthenticationException(Exception):
 
 
 @frozen
-class HttpException(Exception):
+class HttpException(ManteloException):
     """
     Exception raised on HTTP errors when talking to the Keycloak Admin API.
     """
@@ -26,18 +32,49 @@ class HttpException(Exception):
     status_code: int
     """The HTTP status code."""
     json: dict
-    """The JSON response from the server."""
+    """The JSON response from the server, or an empty JSON if the body is not JSON."""
     url: str
     """The URL that was requested."""
     response: requests.Response = field(repr=False)
     """The response object from the server."""
 
     @classmethod
-    def from_slumber_exception(cls, ex: SlumberHttpBaseException):
-        assert hasattr(ex, "response")
+    def from_response(cls, response: requests.Response) -> "HttpException":
+        json = {}
+        try:
+            # Most API use JSON, but not all!
+            json = response.json()
+        except Exception:  # noqa: S110
+            pass
+
         return cls(
-            url=ex.response.request.url,
-            status_code=ex.response.status_code,
-            json=ex.response.json() if ex.response.content else {},
-            response=ex.response,
+            url=response.request.url or "",
+            status_code=response.status_code,
+            json=json,
+            response=response,
         )
+
+
+@frozen
+class HttpClientError(HttpException):
+    """
+    Called when the server tells us there was a client error (4xx).
+    """
+
+
+class HttpNotFound(HttpClientError):
+    """
+    Called when the server sends a 404 error.
+    """
+
+
+class HttpServerError(HttpException):
+    """
+    Called when the server tells us there was a server error (5xx).
+    """
+
+
+class SerializerNoAvailable(ManteloException):
+    """
+    The serializer for the content type is not available.
+    """

--- a/mantelo/internal/__init__.py
+++ b/mantelo/internal/__init__.py
@@ -1,0 +1,10 @@
+"""
+
+Highly inspired by the awesome :py:mod:`slumber` library, the internal module implements the
+low-level functionality of the library, including the translation from Python code to HTTP calls.
+
+.. warning::
+
+    This module is considered internal and its API may change at any time.
+
+"""

--- a/mantelo/internal/api.py
+++ b/mantelo/internal/api.py
@@ -1,0 +1,422 @@
+"""
+This module is highly inspired from the awesome slumber library. I decided to port it to mantelo
+(with some improvements) due to the lack of active development in slumber since 2018.
+
+Please, do not use :class:`~.API` directly, but use :class:`~.KeycloakAdmin` instead.
+"""
+
+from posixpath import join as pathjoin
+from typing import Any, TypeAlias
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+import requests.auth
+from attrs import evolve, field, frozen
+
+from .. import exceptions
+from .serializers import BaseSerializer, JsonSerializer
+
+
+DecodedResponse: TypeAlias = dict | str | bytes
+"""
+The decoded response as a dict, or as a string if no serializer is defined
+or the body is empty. If the body cannot be decoded, the raw bytes are returned
+instead of throwing an error.
+"""
+
+HttpResponse: TypeAlias = (
+    DecodedResponse | tuple[requests.Response, DecodedResponse]
+)
+"""
+Either the decoded response or a tuple with the raw response and the decoded body
+(see :py:meth:`Resource.as_raw`).
+"""
+
+
+def url_join(base: str, *args: Any) -> str:
+    """
+    Join any number of segments to a base URL.
+    Segments not of type string will be converted to strings using :func:`str`.
+    """
+    scheme, netloc, path, query, fragment = urlsplit(base)
+    path = pathjoin(path if len(path) else "/", *(str(x) for x in args))
+    return urlunsplit([scheme, netloc, path, query, fragment])
+
+
+@frozen
+class Store:
+    """
+    The holder of all the state for a given resource.
+    It is immutable, use :meth:`evolve` to create a new instance with updated values.
+    """
+
+    base_url: str
+    """The URL this resource targets."""
+    session: requests.Session
+    """The session to use for all HTTP requests."""
+    serializers: list[BaseSerializer] = field()
+    """
+    The serializers available for decoding the response's data.
+    The first serializer is the default one, used also for encoding the request's data.
+    """
+    append_slash: bool = True
+    """
+    Whether to append a slash to the URL before making the request.
+    """
+    raw: bool = False
+    """
+    Whether to return the raw response object along with the decoded body.
+    """
+
+    @serializers.validator
+    def _check_serializers(self, _attribute: str, value: Any) -> None:
+        if not isinstance(value, list) or len(value) < 1:
+            raise ValueError("At least one serializer is required")
+
+    @property
+    def default_serializer(self) -> BaseSerializer:
+        """The serializer used to encode the request's data."""
+        return self.serializers[0]
+
+    def get_serializer(self, content_type: str) -> BaseSerializer | None:
+        """Get the first serializer that matches the given content type, if any."""
+        return next(
+            (
+                s
+                for s in self.serializers
+                if s.matches_content_type(content_type)
+            ),
+            None,
+        )
+
+    def evolve(self, **kwargs: Any) -> "Store":
+        """Create a new instance with the given values mutated."""
+        return evolve(self, **kwargs)
+
+
+class Resource:
+    """
+    The magic behind URL translation.
+
+    It provides the magic of translating python code to URLs and HTTP calls. Each instance of a
+    resource is tied to a specific URL, and can evolve to a new URL by calling an unknown property
+    or attribute. To finally make an HTTP call, use one of the defined methods (:meth:`get`,
+    :meth:`post`, etc).
+
+    By default, all HTTP calls return the decoded body (see :py:class:`HttpResponse`), but you can
+    also get hold of the raw response by calling :func:`as_raw`.
+
+    :param store: The store object that holds all the state for this resource.
+    :type store: _Store
+    """
+
+    def __init__(self, store: Store):
+        self._store = store
+
+    def __getattr__(self, item: str) -> "Resource":
+        """
+        Add a path segment to the URL.
+        """
+
+        # Don't allow access to 'private' by convention attributes.
+        # @@@: How would this work with resources names that begin with
+        # underscores?
+        if item.startswith("_"):
+            raise AttributeError(item)
+
+        base_url = url_join(self._store.base_url, item.replace("_", "-"))
+
+        return self._get_resource(self._store.evolve(base_url=base_url))
+
+    def __call__(
+        self, id: Any = None, /, url_override: str | None = None
+    ) -> "Resource":
+        """
+        Add a path segment to the URL, or override the URL entirely.
+
+        Use it instead of :func:`__getattr__` either for readability (e.g.
+        :python:`api.user("xxx")`), or because the path segment isn't valid Python (e.g.
+        :python:`api("123")`).
+
+        :param id: The path segment to add to the URL.
+        :type id: any, optional
+        :param url_override: The URL to use instead of the current one.
+        :type url_override: string, optional
+        :return: A new resource with the updated URL.
+        :rtype: Resource
+        """
+
+        # Short Circuit out if the call is empty
+        if id is None and url_override is None:
+            return self
+
+        base_url = self._store.base_url
+
+        if id is not None:
+            base_url = url_join(self._store.base_url, id)
+
+        if url_override is not None:
+            # @@@ This is hacky and we should probably figure out a better way
+            #    of handling the case when a POST/PUT doesn't return an object
+            #    but a Location to an object that we need to GET.
+            base_url = url_override
+
+        return self._get_resource(self._store.evolve(base_url=base_url))
+
+    def _request(
+        self,
+        method: str,
+        data: dict | None = None,
+        files: dict | None = None,
+        params: dict | None = None,
+    ) -> requests.Response:
+        serializer = self._store.default_serializer
+        url = self.url()
+
+        headers = {"accept": serializer.content_type}
+        body: dict | str | None = data
+
+        if not files and data is not None:
+            # The files parameter has the priority (and will be used in the body),
+            # but if we manually set the content-type, requests will not override it
+            # with multipart/form-data.
+            headers["content-type"] = serializer.content_type
+            body = serializer.dumps(data)
+
+        resp = self._store.session.request(
+            method, url, data=body, params=params, files=files, headers=headers
+        )
+
+        self._ = resp
+
+        if 400 <= resp.status_code <= 499:
+            if resp.status_code == 404:
+                raise exceptions.HttpNotFound.from_response(resp)
+            raise exceptions.HttpClientError.from_response(resp)
+
+        if 500 <= resp.status_code <= 599:
+            raise exceptions.HttpServerError.from_response(resp)
+
+        return resp
+
+    def _parse_response_body(self, resp: requests.Response) -> DecodedResponse:
+        if resp.status_code in [204, 205]:
+            return ""  # requests.content and requests.text do the same
+
+        try:
+            body = resp.text
+        except UnicodeDecodeError:
+            # In case the encoding is not properly set, return the raw bytes
+            return resp.content
+
+        ctype = resp.headers.get("content-type", "").split(";")[0].strip()
+        if (
+            ctype
+            and body
+            and (serializer := self._store.get_serializer(ctype))
+        ):
+            return serializer.loads(body)
+        return body
+
+    def _process_response(self, resp: requests.Response) -> HttpResponse:
+        if not (200 <= resp.status_code <= 299):
+            # TODO: is this check necessary?
+            raise ValueError(
+                "_process_response only support 2xx status codes, "
+                f"got {resp.status_code}"
+            )
+
+        decoded = self._parse_response_body(resp)
+        if self._store.raw:
+            return (resp, decoded)
+
+        return decoded
+
+    def _do_verb_request(
+        self,
+        verb: str,
+        data: dict | None = None,
+        files: dict | None = None,
+        params: dict | None = None,
+    ) -> HttpResponse:
+        resp = self._request(verb, data=data, files=files, params=params)
+        return self._process_response(resp)
+
+    def as_raw(self) -> "Resource":
+        """
+        Make the HTTP calls return both the raw response object and the decoded body.
+        """
+        return self._get_resource(self._store.evolve(raw=True))
+
+    def get(self, **kwargs: Any) -> HttpResponse:
+        """
+        Do a GET request.
+
+        :param kwargs: The query parameters to send with the request.
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request("GET", params=kwargs)
+
+    def options(self, **kwargs: Any) -> HttpResponse:
+        """
+        Do an OPTION request.
+
+        :param kwargs: The query parameters to send with the request.
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request("OPTIONS", params=kwargs)
+
+    def head(self, **kwargs: Any) -> HttpResponse:
+        """
+        Do a HEAD request.
+
+        :param kwargs: The query parameters to send with the request.
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request("HEAD", params=kwargs)
+
+    def post(
+        self,
+        data: dict | None = None,
+        files: dict | None = None,
+        **kwargs: Any,
+    ) -> HttpResponse:
+        """
+        Do a POST request.
+
+        :param data: The data to send with the request.
+        :type data: dict, optional
+        :param files: The files to send with the request. Supersedes :param:data.
+            See `requests.post` for more information.
+        :type files: dict, optional
+        :param kwargs: The query parameters to send with the request.
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request(
+            "POST", data=data, files=files, params=kwargs
+        )
+
+    def patch(
+        self,
+        data: dict | None = None,
+        files: dict | None = None,
+        **kwargs: Any,
+    ) -> HttpResponse:
+        """
+        Do a PATCH request.
+        Parameters are the same as :func:`post`.
+
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request(
+            "PATCH", data=data, files=files, params=kwargs
+        )
+
+    def put(
+        self,
+        data: dict | None = None,
+        files: dict | None = None,
+        **kwargs: Any,
+    ) -> HttpResponse:
+        """
+        Do a PUT request.
+        Parameters are the same as :func:`post`.
+
+        :rtype: HttpResponse
+        """
+        return self._do_verb_request(
+            "PUT", data=data, files=files, params=kwargs
+        )
+
+    def delete(self, **kwargs: Any) -> bool | tuple[requests.Response, bool]:
+        """
+        Do a DELETE request.
+
+        :param kwargs: The query parameters to send with the request.
+        :return: True if the request was successful, False for 3xx status codes.
+        :rtype: bool
+        """
+        resp = self._request("DELETE", params=kwargs)
+        # TODO: isn't this stupid?
+        # The only other possible statues are 3xx...
+        response = 200 <= resp.status_code <= 299
+
+        if self._store.raw:
+            return (resp, response)
+        return response
+
+    def url(self) -> str:
+        """
+        Get the URL that will be used for the next HTTP call.
+        """
+        url = self._store.base_url
+
+        if self._store.append_slash and not url.endswith("/"):
+            url = url + "/"
+
+        return url
+
+    def _get_resource(self, *args: Any, **kwargs: Any) -> "Resource":
+        return self.__class__(*args, **kwargs)
+
+
+class API(Resource):
+    """
+    The main entry point for making HTTP calls to a specific API.
+
+    Highly inspired by the awesome `slumber <https://slumber.readthedocs.io/en/stable/>`_ library,
+    this class defines default parameters for all the requests to an API, such as the base URL, the
+    serializers to use, and the session to use for all requests. Once you have an API object, you
+    can start making calls using, e.g. :python:`api.users.get()`.
+
+    Do NOT use it directly, see :class:`KeycloakAdmin` instead.
+
+    :param base_url: The base URL for the API.
+    :type base_url: string
+    :param auth: The authentication object to use for all requests.
+    :type auth: requests.auth.AuthBase, optional
+    :param append_slash: Whether to append a slash to the URL before making the request.
+    :type append_slash: bool, optional
+    :param session: The session to use for all request (API and authentication).
+    :type session: requests.Session, optional
+    :param serializers: The serializers to use for encoding and decoding the requests and responses.
+        The first serializer in the list is used for encoding the request's data.
+        Supports JSON by default.
+    :type serializers: list[BaseSerializer], optional
+    :param raw: Whether to return the raw response object along with the decoded body.
+    :type raw: bool, optional
+    """
+
+    _resource_class = Resource
+
+    def __init__(
+        self,
+        base_url: str,
+        auth: requests.auth.AuthBase | None = None,
+        append_slash: bool = True,
+        session: requests.Session | None = None,
+        serializers: list[BaseSerializer] | None = None,
+        raw: bool = False,
+    ):
+        if base_url is None:
+            raise ValueError("base_url is required")
+
+        if serializers is None:
+            serializers = [JsonSerializer()]
+
+        if session is None:
+            session = requests.session()
+
+        if auth is not None:
+            session.auth = auth
+
+        self._store = Store(
+            base_url=base_url,
+            append_slash=append_slash,
+            session=session,
+            serializers=serializers,
+            raw=raw,
+        )
+
+    def _get_resource(self, *args: Any, **kwargs: Any):
+        return self._resource_class(*args, **kwargs)

--- a/mantelo/internal/serializers.py
+++ b/mantelo/internal/serializers.py
@@ -1,0 +1,70 @@
+import json
+from abc import ABC, abstractmethod
+
+
+class BaseSerializer(ABC):
+    """Abstract base class for all serializers."""
+
+    @property
+    def content_type(self) -> str | None:
+        """Default content-type for this serializer."""
+        return next(iter(self.supported_content_types), None)
+
+    @property
+    @abstractmethod
+    def supported_content_types(self) -> list[str]:
+        """
+        Get all the content types this serializer can handle.
+
+        :return: A list of supported content types.
+        :rtype: list
+        """
+
+    def matches_content_type(self, content_type: str) -> bool:
+        """
+        Check if the given content type is supported by this serializer.
+
+        :param content_type: The content type to match.
+        :return: True if the content type is supported, False otherwise.
+        """
+        return content_type in self.supported_content_types
+
+    @abstractmethod
+    def loads(self, data: str) -> dict:
+        """
+        Deserialize a string into a dictionary.
+
+        :param data: The string to deserialize.
+        :return: The deserialized dictionary.
+        :rtype: dict
+        """
+
+    @abstractmethod
+    def dumps(self, data: dict) -> str:
+        """
+        Serialize a dictionary into a string.
+
+        :param data: The dictionary to serialize.
+        :return: The serialized string.
+        :rtype: str
+        """
+
+
+class JsonSerializer(BaseSerializer):
+    """A serializer for JSON data."""
+
+    @property
+    def supported_content_types(self) -> list[str]:
+        return [
+            "application/json",
+            "application/x-javascript",
+            "text/javascript",
+            "text/x-javascript",
+            "text/x-json",
+        ]
+
+    def loads(self, data: str) -> dict:
+        return json.loads(data)
+
+    def dumps(self, data: dict) -> str:
+        return json.dumps(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ requires-python = ">=3.10"
 dependencies = [
   "attrs",
   "requests",
-  "slumber",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
-from mantelo.connection import (
-    UsernamePasswordConnection,
-    ClientCredentialsConnection,
-)
-from . import constants
+from unittest.mock import MagicMock
+
 import pytest
+
+from mantelo.internal import serializers
+from mantelo.connection import (
+    ClientCredentialsConnection,
+    UsernamePasswordConnection,
+)
+from mantelo.internal import api
+
+from . import constants
 
 
 @pytest.fixture()
@@ -35,4 +41,26 @@ def openid_connection_admin():
         client_id=constants.ADMIN_CLI_CLIENT,
         username=constants.TEST_MASTER_USER,
         password=constants.TEST_MASTER_PASSWORD,
+    )
+
+
+@pytest.fixture()
+def mock_session():
+    session = MagicMock()
+    session.request.return_value = MagicMock(status_code=200)
+    for session_method in ["get", "post", "put", "delete"]:
+        getattr(
+            session, session_method
+        ).return_value = session.request.return_value
+    return session
+
+
+@pytest.fixture()
+def mock_store(mock_session):
+    return api.Store(
+        base_url="https://example.com",
+        serializers=[serializers.JsonSerializer()],
+        session=mock_session,
+        append_slash=False,
+        raw=False,
     )

--- a/tests/internal/test_api.py
+++ b/tests/internal/test_api.py
@@ -1,0 +1,394 @@
+from unittest.mock import MagicMock, Mock, PropertyMock
+
+import pytest
+import requests
+
+from mantelo.internal import api as _api
+from mantelo import exceptions
+from mantelo.internal.serializers import JsonSerializer
+
+
+def test_store_evolve(mock_store):
+    new_store = mock_store.evolve(
+        base_url="new_base_url",
+        raw=True,
+    )
+
+    assert isinstance(new_store, _api.Store)
+    assert new_store != mock_store
+    assert new_store.session == mock_store.session
+    assert new_store.base_url == "new_base_url"
+    assert new_store.raw is True
+
+
+@pytest.mark.parametrize("serializers", [[], None, "not a list"])
+def test_store_validate_serializers(mock_store, serializers):
+    with pytest.raises(ValueError) as excinfo:
+        mock_store.evolve(serializers=serializers)
+    assert str(excinfo.value) == "At least one serializer is required"
+
+
+@pytest.mark.parametrize(
+    ("base", "parts", "expected"),
+    [
+        ("", [], "/"),
+        ("/", [], "/"),
+        ("/some/path/", ["test", "foo"], "/some/path/test/foo"),
+        ("http://example.com", [], "http://example.com/"),
+        ("https://port.com:433/foo", [], "https://port.com:433/foo"),
+        (
+            "http://path-in-base.com/path/test/",
+            ["foo/"],
+            "http://path-in-base.com/path/test/foo/",
+        ),
+        (
+            "http://slashes.com/",
+            ["/test/", "foo"],
+            "http://slashes.com/test/foo",
+        ),
+        (
+            "http://to-string.com",
+            ["test", 1, "bar", False],
+            "http://to-string.com/test/1/bar/False",
+        ),
+    ],
+)
+def test_url_join(base, parts, expected):
+    assert _api.url_join(base, *parts) == expected
+
+
+@pytest.mark.parametrize(
+    "base_url", ["http://x.com", "http://x.com/something"]
+)
+@pytest.mark.parametrize(
+    ("resource", "expected_path"),
+    [
+        (lambda api: api, ""),
+        (lambda api: api.foo, "foo"),
+        (lambda api: api.foo.bar, "foo/bar"),
+        (lambda api: api.foo("123").bar, "foo/123/bar"),
+        (lambda api: api.foo(123).bar(), "foo/123/bar"),
+        (lambda api: api.under_score, "under-score"),
+        (lambda api: api("under-score")("foo-bar"), "under-score/foo-bar"),
+    ],
+)
+@pytest.mark.parametrize("append_slash", [True, False])
+def test_resource_url(base_url, resource, expected_path, append_slash):
+    api = _api.API(base_url=base_url, append_slash=append_slash)
+
+    expected = f"{base_url}/{expected_path}" if expected_path else base_url
+    if append_slash:
+        expected += "/"
+
+    assert resource(api).url() == expected
+
+
+def test_resource_url_override():
+    api = _api.API(base_url="A")
+    # It replaces everything so far
+    assert api(url_override="B").url() == "B/"
+    assert api.foo.bar(url_override="B").buzz.url() == "B/buzz/"
+    assert api.foo.bar(url_override="B").buzz(url_override="C").url() == "C/"
+
+
+def test_resource_request(mock_store):
+    mock_response = mock_store.session.request.return_value
+    resource = _api.Resource(
+        mock_store.evolve(
+            base_url="base_url",
+            serializers=[Mock(content_type="ctype")],
+        )
+    )
+
+    assert (
+        resource._request("METHOD", files="file", params="params")
+        == mock_response
+    )
+    assert resource._ == mock_response
+
+    mock_store.session.request.assert_called_with(
+        "METHOD",
+        "base_url",
+        data=None,
+        params="params",
+        files="file",
+        headers={"accept": "ctype"},
+    )
+
+
+@pytest.mark.parametrize("append_slash", [True, False])
+def test_resource_request_append_slash(mock_session, mock_store, append_slash):
+    resource = _api.Resource(
+        mock_store.evolve(
+            base_url="https://example.com/foo",
+            append_slash=append_slash,
+        )
+    )
+    resource._request("METHOD")
+    mock_session.request.assert_called_once()
+    if append_slash:
+        assert (
+            mock_session.request.call_args[0][1] == "https://example.com/foo/"
+        )
+    else:
+        assert (
+            mock_session.request.call_args[0][1] == "https://example.com/foo"
+        )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (100, None),
+        (200, None),
+        (300, None),
+        (400, exceptions.HttpClientError),
+        (404, exceptions.HttpNotFound),
+        (499, exceptions.HttpClientError),
+        (500, exceptions.HttpServerError),
+        (599, exceptions.HttpServerError),
+    ],
+)
+def test_resource_request_http_response(
+    mock_store, mock_session, status_code, expected
+):
+    mock_response = Mock(status_code=status_code)
+    mock_session.request.return_value = mock_response
+    resource = _api.Resource(mock_store)
+
+    if expected is None:
+        assert resource._request("METHOD") == mock_response
+    else:
+        with pytest.raises(expected) as excinfo:
+            resource._request("METHOD")
+        assert excinfo.value.response == mock_response
+
+
+def test_resource_request_body(mock_store):
+    mock_store.session.request.return_value = Mock(status_code=200)
+    resource = _api.Resource(mock_store)
+
+    # the data should be serialized and the content-type header set
+    resource._request("POST", data={"foo": "bar"})
+    mock_store.session.request.assert_called_with(
+        "POST",
+        "https://example.com",
+        data='{"foo": "bar"}',
+        params=None,
+        files=None,
+        headers={
+            "accept": "application/json",
+            "content-type": "application/json",
+        },
+    )
+
+    # if files is provided, data should be sent raw and more importantly
+    # the content-type should NOT be set
+    mock_store.session.reset_mock()
+    resource._request("POST", data={"foo": "bar"}, files="file")
+    mock_store.session.request.assert_called_with(
+        "POST",
+        "https://example.com",
+        data={"foo": "bar"},  # will be ignored by requests anyway
+        params=None,
+        files="file",
+        headers={"accept": "application/json"},
+    )
+
+
+@pytest.mark.parametrize("status_code", [204, 205])
+def test_resource_parse_response_body_skip(status_code):
+    resource = _api.Resource(Mock())
+    assert resource._parse_response_body(Mock(status_code=status_code)) == ""
+
+
+@pytest.mark.parametrize(
+    ("content_type", "content"),
+    [
+        (None, None),
+        ("application/json", None),
+        ("application/json", ""),
+        (None, '{"foo": "bar"}'),
+        ("", '{"foo": "bar"}'),
+    ],
+)
+def test_resource_parse_response_body_no_decode(content_type, content):
+    mock_response = Mock(status_code=200, text=content, headers={})
+    if content_type is not None:
+        mock_response.headers = {"content-type": content_type}
+
+    resource = _api.Resource(Mock())
+    assert resource._parse_response_body(mock_response) == mock_response.text
+    resource._store.get_serializer.assert_not_called()
+
+
+def test_resource_parse_response_bytes():
+    mock_response = Mock(
+        status_code=200,
+        content=b"bytes",
+        headers={},
+    )
+    # Make resp.text raise an exception
+    type(mock_response).text = PropertyMock(
+        side_effect=UnicodeDecodeError("", b"", 0, 1, "")
+    )
+
+    resource = _api.Resource(Mock())
+    assert resource._parse_response_body(mock_response) == b"bytes"
+    resource._store.get_serializer.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("ctype", "expected"),
+    [
+        ("FOO-BAR", None),
+        ("foobar", None),
+        ("foo-bar;", 0),
+        ("  foo-bar    ;   ", 0),
+        ("application/json", 2),
+        ("application/json; charset=utf-8", 2),
+        ("text/json;", None),
+    ],
+)
+def test_resource_parse_response_body_choose_serializer(ctype, expected):
+    mock_response = Mock(
+        status_code=200,
+        text="any",
+        headers={"content-type": ctype},
+    )
+
+    resource = _api.Resource(
+        _api.Store(
+            base_url="any",
+            session=Mock(),
+            serializers=[
+                MagicMock(matches_content_type=lambda s: s == "foo-bar"),
+                MagicMock(matches_content_type=lambda s: s == "text/yaml"),
+                MagicMock(
+                    matches_content_type=lambda s: s == "application/json"
+                ),
+            ],
+        )
+    )
+    resp = resource._parse_response_body(mock_response)
+
+    if expected is None:
+        assert resp == "any"
+    else:
+        assert resp == resource._store.serializers[expected].loads.return_value
+
+
+@pytest.mark.parametrize("raw", [True, False])
+def test_resource_process_response(mock_store, raw):
+    resource = _api.Resource(mock_store.evolve(raw=raw))
+    resource._parse_response_body = Mock(return_value="decoded")
+    mock_response = Mock(status_code=200)
+
+    result = resource._process_response(mock_response)
+    if raw:
+        assert result == (mock_response, "decoded")
+    else:
+        assert result == "decoded"
+
+
+def test_resource_process_response_invalid_status(mock_store):
+    resource = _api.Resource(mock_store.evolve(raw=False))
+
+    with pytest.raises(ValueError) as excinfo:
+        resource._process_response(Mock(status_code=500))
+
+    assert (
+        str(excinfo.value)
+        == "_process_response only support 2xx status codes, got 500"
+    )
+
+
+def test_resource_do_verb_request(mock_store):
+    resource = _api.Resource(mock_store)
+    resource._request = Mock(return_value="response")
+    resource._process_response = Mock()
+
+    resource._do_verb_request(
+        "GET", data="data", files="files", params="params"
+    )
+
+    resource._request.assert_called_with(
+        "GET", data="data", files="files", params="params"
+    )
+    resource._process_response.assert_called_with("response")
+
+
+def test_resource_as_raw(mock_store):
+    resource = _api.Resource(mock_store.evolve(raw=False))
+    response = resource.as_raw()
+
+    assert isinstance(response, _api.Resource)
+    assert response != resource
+    assert response._store.raw is True
+
+
+@pytest.mark.parametrize("method", ["get", "options", "head"])
+def test_resource_get_options_head(mock_store, method):
+    resource = _api.Resource(mock_store)
+    resource._do_verb_request = Mock(return_value="response")
+
+    assert getattr(resource, method)(foo="bar") == "response"
+
+    resource._do_verb_request.assert_called_with(
+        method.upper(), params={"foo": "bar"}
+    )
+
+
+@pytest.mark.parametrize("method", ["post", "patch", "put"])
+def test_resource_post_patch_put(mock_store, method):
+    resource = _api.Resource(mock_store)
+    resource._do_verb_request = Mock(return_value="response")
+
+    assert (
+        getattr(resource, method)(data="data", files="files", foo="bar")
+        == "response"
+    )
+
+    resource._do_verb_request.assert_called_with(
+        method.upper(), data="data", files="files", params={"foo": "bar"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"), [(200, True), (301, False)]
+)
+@pytest.mark.parametrize("raw", [True, False])
+def test_resource_delete(mock_store, raw, status_code, expected):
+    mock_response = Mock(status_code=status_code)
+    resource = _api.Resource(mock_store.evolve(raw=raw))
+    resource._request = Mock(return_value=mock_response)
+
+    response = resource.delete(foo="bar")
+
+    resource._request.assert_called_with("DELETE", params={"foo": "bar"})
+
+    if raw:
+        assert response == (mock_response, expected)
+    else:
+        assert response == expected
+
+
+def test_api_init():
+    with pytest.raises(ValueError) as excinfo:
+        _api.API(base_url=None)
+    assert str(excinfo.value) == "base_url is required"
+
+    # Test default values
+    api = _api.API(base_url="http://example.com")
+    assert isinstance(api._store.default_serializer, JsonSerializer)
+    assert isinstance(api._store.session, requests.Session)
+    assert api._store.append_slash is True
+    assert api._store.raw is False
+
+    # Test auth
+    api = _api.API(base_url="http://example.com", auth="auth")
+    assert api._store.session.auth == "auth"
+
+    # Test empty serializers
+    with pytest.raises(ValueError):
+        _api.API(base_url="http://example.com", serializers=[])

--- a/tests/internal/test_serialiers.py
+++ b/tests/internal/test_serialiers.py
@@ -1,0 +1,27 @@
+from mantelo.internal.serializers import JsonSerializer
+
+
+def test_content_type():
+    assert JsonSerializer().content_type == "application/json"
+
+
+def test_supported_content_types():
+    assert JsonSerializer().supported_content_types == [
+        "application/json",
+        "application/x-javascript",
+        "text/javascript",
+        "text/x-javascript",
+        "text/x-json",
+    ]
+
+
+def test_load_dump():
+    data = {
+        "foo": "bar",
+        "baz": 42,
+        "qux": True,
+        "elantris": {"Sarene": "Raoden", "Hrathen": [1, 2, 3]},
+    }
+    ser = JsonSerializer().dumps(data)
+    assert isinstance(ser, str)
+    assert JsonSerializer().loads(ser) == data

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 import pytest
-from . import constants
+import requests
+
 from mantelo import KeycloakAdmin
 from mantelo.client import BearerAuth
 from mantelo.exceptions import HttpException
-import requests
+
+from . import constants
 
 
 @pytest.mark.integration
@@ -122,7 +124,7 @@ def test_switch_realm(openid_connection_admin):
         (
             401,
             lambda c: (
-                setattr(c._store["session"], "auth", None),
+                setattr(c._store.session, "auth", None),
                 c.users.get(),
             )[-1],
         ),


### PR DESCRIPTION
…nto Mantelo

slumber's last activity was in 2018.
Better to make it part of Keycloak, so it can evolve and I can fix issues directly.

I didn't just copy the code, but made small improvements and typed it properly.

BEGIN_NESTED_COMMIT
docs: document "as_raw" to get the raw response
END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
feat!: return an empty string (versus b'' or None) when the body is empty END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
feat: raise more granular HttpException (HttpNotFound, HttpClientError, HttpServerError) END_NESTED_COMMIT

BEGIN_NESTED_COMMIT
fix: make HttpException handle responses with non-empty, non-JSON body END_NESTED_COMMIT