### PR TITLE
fix: allow DELETE to have a body

### DIFF
--- a/docs/02-making-calls.rst
+++ b/docs/02-making-calls.rst
@@ -28,7 +28,7 @@ information):
 * :python:`.post(data=None, files=None, **kwargs)`
 * :python:`.patch(data=None, files=None, **kwargs)`
 * :python:`.put(data=None, files=None, **kwargs)`
-* :python:`.delete(**kwargs)`
+* :python:`.delete(data=None, files=None, **kwargs)`
 
 The ``kwargs`` can be used to add query parameters to the URL. The ``data`` and ``files`` parameters
 can be used to add a payload to the request. See :py:meth:`requests.Session.request` for more

--- a/mantelo/internal/api.py
+++ b/mantelo/internal/api.py
@@ -328,15 +328,25 @@ class Resource:
             "PUT", data=data, files=files, params=kwargs
         )
 
-    def delete(self, **kwargs: Any) -> bool | tuple[requests.Response, bool]:
+    def delete(
+        self,
+        data: dict | None = None,
+        files: dict | None = None,
+        **kwargs: Any,
+    ) -> bool | tuple[requests.Response, bool]:
         """
         Do a DELETE request.
+        Parameters are the same as :func:`post`.
 
-        :param kwargs: The query parameters to send with the request.
+        *Note*: some APIs such as the Keycloak Admin REST Api do not follow the HTTP spec and expect
+        a body in the request (e.g.
+        ``DELETE /admin/realms/{realm}/users/{user-id}/role-mappings/clients/{client-id}``).
+
+
         :return: True if the request was successful, False for 3xx status codes.
         :rtype: bool
         """
-        resp = self._request("DELETE", params=kwargs)
+        resp = self._request("DELETE", data=data, files=files, params=kwargs)
         # TODO: isn't this stupid?
         # The only other possible statues are 3xx...
         response = 200 <= resp.status_code <= 299

--- a/tests/internal/test_api.py
+++ b/tests/internal/test_api.py
@@ -363,9 +363,11 @@ def test_resource_delete(mock_store, raw, status_code, expected):
     resource = _api.Resource(mock_store.evolve(raw=raw))
     resource._request = Mock(return_value=mock_response)
 
-    response = resource.delete(foo="bar")
+    response = resource.delete(data="data", files="files", foo="bar")
 
-    resource._request.assert_called_with("DELETE", params={"foo": "bar"})
+    resource._request.assert_called_with(
+        "DELETE", data="data", files="files", params={"foo": "bar"}
+    )
 
     if raw:
         assert response == (mock_response, expected)


### PR DESCRIPTION
The Keycloak Admin doesn't follow the HTTP spec, and expects a body in some delete calls. For example:

DELETE
/admin/realms/{realm}/users/{user-id}/role-mappings/clients/{client-id}

This commit changes the DELETE signature to match a POST.

Closes: #17 