### PR TITLE
docs: remove duplicated `Instead,`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 
 > Mantelo [manˈtelo], from German "*Mantel*", from Late Latin "*mantum*" means "*cloak*" in Esperanto.
 
-It stays fresh and complete because it does not hard-code or wrap any endpoint. Instead, Instead, it
-offers a clean, object-oriented interface to the Keycloak RESTful API. Acting as a lightweight
-wrapper around the popular [requests](https://requests.readthedocs.io/en/latest/) library, mantelo
-takes care of all the boring details for you - like authentication (tokens and refresh tokens), URL
+It stays fresh and complete because it does not hard-code or wrap any endpoint. Instead, it offers 
+a clean, object-oriented interface to the Keycloak RESTful API. Acting as a lightweight wrapper 
+around the popular [requests](https://requests.readthedocs.io/en/latest/) library, mantelo takes 
+care of all the boring details for you - like authentication (tokens and refresh tokens), URL
 management, serialization, and request processing
 
 Any endpoint your Keycloak supports, mantelo supports!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,8 @@ Mantelo: A Keycloak Admin REST Api Client for Python
    Mantelo [manˈtelo], from German "*Mantel*", from Late Latin "*mantum*" means "*cloak*" in Esperanto.
 
 It always stays **fresh** and **complete** because it does not hard-code or wrap any endpoint.
-Instead, Instead, it offers a clean, object-oriented interface to the Keycloak RESTful API. Acting
-as a lightweight wrapper around the popular `requests <https://requests.readthedocs.io/en/latest/>`_
+Instead, it offers a clean, object-oriented interface to the Keycloak RESTful API. Acting as a 
+lightweight wrapper around the popular `requests <https://requests.readthedocs.io/en/latest/>`_
 library, mantelo takes care of all the boring details for you - like authentication (tokens and
 refresh tokens), URL management, serialization, and request processing [#mention]_.
 


### PR DESCRIPTION
Just fixing a small mistake on docs.

It ain't much but it's honest work!